### PR TITLE
Fix package name formatting in CI workflow and update README badges

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Wait for PyPI propagation
         run: |
           echo "Waiting for PyPI package to be available..."
-          PACKAGE_NAME="access-mopper"
+          PACKAGE_NAME="access_mopper"
           VERSION=$(python -c "import versioneer; print(versioneer.get_version())")
           echo "Looking for package: ${PACKAGE_NAME}==${VERSION}"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ACCESS Model Output Post-Processor (ACCESS-MOPPeR) v2
 
 [![Documentation Status](https://readthedocs.org/projects/access-mopper-v2/badge/?version=latest)](https://access-mopper-v2.readthedocs.io/en/latest/?badge=latest)
-[![PyPI version](https://badge.fury.io/py/access-mopper.svg)](https://badge.fury.io/py/access-mopper)
-[![Conda Version](https://img.shields.io/conda/vn/conda-forge/access-mopper.svg)](https://anaconda.org/conda-forge/access-mopper)
+[![PyPI version](https://badge.fury.io/py/access_mopper.svg)](https://badge.fury.io/py/access_mopper)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/access_mopper.svg)](https://anaconda.org/conda-forge/access_mopper)
 
 ACCESS-MOPPeR is a CMORisation tool designed to post-process ACCESS model output and produce CMIP-compliant datasets. This version represents a significant rewrite focusing on usability, flexibility, and integration with modern Python workflows.
 


### PR DESCRIPTION
This pull request updates the package name references from `access-mopper` to `access_mopper` to ensure consistency across documentation and deployment scripts. This change helps avoid issues with package discovery and installation, particularly on PyPI and Conda.

Package naming consistency:

* Updated PyPI and Conda badge links in `README.md` to use `access_mopper` instead of `access-mopper`, ensuring documentation matches the actual package name.
* Changed the `PACKAGE_NAME` variable in `.github/workflows/cd.yml` from `access-mopper` to `access_mopper` to align with the correct package name during deployment.