### PR TITLE
Fix to iris

### DIFF
--- a/src/access_mopper/driver.py
+++ b/src/access_mopper/driver.py
@@ -113,21 +113,15 @@ class ACCESS_ESM_CMORiser:
 
     def to_iris(self):
         """
-        Converts the underlying xarray Dataset to Iris CubeList format.
-        Requires iris and iris.experimental.xarray to be installed.
+        Converts the underlying xarray Dataset to Iris CubeList format using ncdata for lossless conversion.
+        Requires ncdata and iris to be installed.
         """
         try:
-            if len(self.cmoriser.ds.data_vars) == 1:
-                # Single cube
-                import iris
-                return iris.cube.Cube.from_xarray_dataset(self.cmoriser.ds)
-            else:
-                # Multiple cubes
-                import iris
-                return iris.cube.CubeList.from_xarray_dataset(self.cmoriser.ds)
+            from ncdata.iris_xarray import cubes_from_xarray
+            return cubes_from_xarray(self.cmoriser.ds)
         except ImportError:
             raise ImportError(
-                "iris is required for to_iris(). Please install iris."
+                "ncdata and iris are required for to_iris(). Please install ncdata and iris."
             )
 
     def run(self, write_output: bool = False):

--- a/src/access_mopper/driver.py
+++ b/src/access_mopper/driver.py
@@ -117,12 +117,17 @@ class ACCESS_ESM_CMORiser:
         Requires iris and iris.experimental.xarray to be installed.
         """
         try:
-            from iris.experimental.xarray import as_cubes
-
-            return as_cubes(self.cmoriser.ds)
+            if len(self.cmoriser.ds.data_vars) == 1:
+                # Single cube
+                import iris
+                return iris.cube.Cube.from_xarray_dataset(self.cmoriser.ds)
+            else:
+                # Multiple cubes
+                import iris
+                return iris.cube.CubeList.from_xarray_dataset(self.cmoriser.ds)
         except ImportError:
             raise ImportError(
-                "iris and iris.experimental.xarray are required for to_iris(). Please install iris."
+                "iris is required for to_iris(). Please install iris."
             )
 
     def run(self, write_output: bool = False):


### PR DESCRIPTION
Ncdata can convert Iris cubes to an Xarray dataset, or vice versa, with minimal
overhead and as lossless as possible.

For example :

.. code-block:: python

      from ncdata.iris_xarray import cubes_from_xarray, cubes_to_xarray
      cubes = cubes_from_xarray(dataset)
      xrds = cubes_to_xarray(cubes)