### PR TITLE
Amon rlus rsus mappings

### DIFF
--- a/src/access_mopper/mappings/Mappings_CMIP6_Amon.json
+++ b/src/access_mopper/mappings/Mappings_CMIP6_Amon.json
@@ -405,7 +405,7 @@
                 "fld_s03i332"
               ]
             },
-            "fld_s02i20"
+            "fld_s02i205"
           ]
         }
     },
@@ -529,7 +529,7 @@
             "operation": "subtract",
             "operands": [
                 "fld_s01i235",
-                "fld_s02i201"
+                "fld_s01i201"
             ]
         }
     },


### PR DESCRIPTION
Looked like there were a couple typos for `rlus` and `rsus` 
cmoriser run with this