### PR TITLE
Esm16 mapping based on discussion with Peter Dobrohoff

### DIFF
--- a/src/access_mopper/mappings/Mappings_CMIP6_Amon.json
+++ b/src/access_mopper/mappings/Mappings_CMIP6_Amon.json
@@ -204,6 +204,23 @@
             "formula": "fld_s30i205"
         }
     },
+    "huss": {
+        "CF standard Name": "specific_humidity",
+        "dimensions": {
+            "time": "time",
+            "lat_v": "lat",
+            "lon_u": "lon"
+        },
+        "units": "1",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i237"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i237"
+        }
+    },
     "hurs": {
         "CF standard Name": "relative_humidity",
         "dimensions": {
@@ -219,6 +236,98 @@
         "calculation": {
             "type": "direct",
             "formula": "fld_s03i245"
+        }
+    },
+    "mc": {
+        "CF standard Name": "atmosphere_net_upward_convective_mass_flux",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "kg m-2 s-1",
+        "positive": "up",
+        "model_variables": [
+            "fld_s05i250",
+            "fld_s05i251"
+        ],
+        "calculation": {
+            "type": "formula",
+            "operation": "level_to_height",
+            "operands": [
+            {
+                "operation": "divide",
+                "operands": [
+                {
+                  "operation": "subtract",
+                  "operands": [
+                    "fld_s05i250",
+                    "fld_s05i251"
+                  ]
+                },
+                9.80665
+                ]
+            }
+            ]
+        }
+    },
+    "pfull": {
+        "CF standard Name": "air_pressure",
+        "dimensions": {
+            "time": "time",
+            "alevel": "model_theta_level_number",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "Pa",
+        "positive": null,
+        "model_variables": [
+            "fld_s00i408"
+        ],
+        "calculation": {
+            "type": "formula",
+            "operation": "level_to_height",
+            "operands": [
+                "fld_s00i408"
+              ]
+            }
+    },
+    "phalf": {
+        "CF standard Name": "air_pressure",
+        "dimensions": {
+            "time": "time",
+            "alevel": "model_rho_level_number",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "Pa",
+        "positive": null,
+        "model_variables": [
+            "fld_s00i407"
+        ],
+        "calculation": {
+            "type": "formula",
+            "operation": "level_to_height",
+            "operands": [
+                "fld_s00i407"
+              ]
+            }
+    },
+    "pr": {
+        "CF standard Name": "precipitation_flux",
+        "dimensions":{
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "kg m-2 s-1",
+        "positive": null,
+        "model_variables": [
+            "fld_s05i216"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s05i216"
         }
     },
     "prc": {
@@ -241,23 +350,6 @@
                 "fld_s05i205",
                 "fld_s05i206"
             ]
-        }
-    },
-    "pr": {
-        "CF standard Name": "precipitation_flux",
-        "dimensions":{
-            "time": "time",
-            "lat": "lat",
-            "lon": "lon"
-        },
-        "units": "kg m-2 s-1",
-        "positive": null,
-        "model_variables": [
-            "fld_s05i216"
-        ],
-        "calculation": {
-            "type": "direct",
-            "formula": "fld_s05i216"
         }
     },
     "prsn": {
@@ -342,23 +434,6 @@
             "formula": "fld_s16i222"
         }
     },
-    "rldscs": {
-        "CF standard Name": "surface_downwelling_longwave_flux_in_air_assuming_clear_sky",
-        "dimensions":{
-            "time": "time",
-            "lat": "lat",
-            "lon": "lon"
-        },
-        "units": "W m-2",
-        "positive": "down",
-        "model_variables": [
-            "fld_s02i208"
-        ],
-        "calculation": {
-            "type": "direct",
-            "formula": "fld_s02i208"
-        }
-    },
     "rlds": {
         "CF standard Name": "surface_downwelling_longwave_flux_in_air",
         "dimensions":{
@@ -374,6 +449,23 @@
         "calculation": {
             "type": "direct",
             "formula": "fld_s02i207"
+        }
+    },
+    "rldscs": {
+        "CF standard Name": "surface_downwelling_longwave_flux_in_air_assuming_clear_sky",
+        "dimensions":{
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "W m-2",
+        "positive": "down",
+        "model_variables": [
+            "fld_s02i208"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s02i208"
         }
     },
     "rlus": {
@@ -409,15 +501,15 @@
           ]
         }
     },
-    "rlutcs": {
-        "CF standard Name": "toa_outgoing_longwave_flux_assuming_clear_sky",
+    "rluscs": {
+        "CF standard Name": "surface_upwelling_longwave_flux_in_air_assuming_clear_sky",
         "dimensions":{
             "time": "time",
             "lat": "lat",
             "lon": "lon"
         },
         "units": "W m-2",
-        "positive": "up",
+        "positive": "down",
         "model_variables": [
             "fld_s02i206"
         ],
@@ -443,21 +535,21 @@
             "formula": "fld_s03i332"
         }
     },
-    "rsdscs": {
-        "CF standard Name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky",
+    "rlutcs": {
+        "CF standard Name": "toa_outgoing_longwave_flux_assuming_clear_sky",
         "dimensions":{
             "time": "time",
             "lat": "lat",
             "lon": "lon"
         },
         "units": "W m-2",
-        "positive": "down",
+        "positive": "up",
         "model_variables": [
-            "fld_s01i210"
+            "fld_s02i206"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s01i210"
+            "formula": "fld_s02i206"
         }
     },
     "rsds": {
@@ -477,6 +569,23 @@
             "formula": "fld_s01i235"
         }
     },
+    "rsdscs": {
+        "CF standard Name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky",
+        "dimensions":{
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "W m-2",
+        "positive": "down",
+        "model_variables": [
+            "fld_s01i210"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s01i210"
+        }
+    },
     "rsdt": {
         "CF standard Name": "toa_incoming_shortwave_flux",
         "dimensions":{
@@ -492,23 +601,6 @@
         "calculation": {
             "type": "direct",
             "formula": "fld_s01i207"
-        }
-    },
-    "rsuscs": {
-        "CF standard Name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky",
-        "dimensions":{
-            "time": "time",
-            "lat": "lat",
-            "lon": "lon"
-        },
-        "units": "W m-2",
-        "positive": "up",
-        "model_variables": [
-            "fld_s01i211"
-        ],
-        "calculation": {
-            "type": "direct",
-            "formula": "fld_s01i211"
         }
     },
     "rsus": {
@@ -533,8 +625,8 @@
             ]
         }
     },
-    "rsutcs": {
-        "CF standard Name": "toa_outgoing_shortwave_flux_assuming_clear_sky",
+    "rsuscs": {
+        "CF standard Name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky",
         "dimensions":{
             "time": "time",
             "lat": "lat",
@@ -543,11 +635,11 @@
         "units": "W m-2",
         "positive": "up",
         "model_variables": [
-            "fld_s01i209"
+            "fld_s01i211"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s01i209"
+            "formula": "fld_s01i211"
         }
     },
     "rsut": {
@@ -565,6 +657,23 @@
         "calculation": {
             "type": "direct",
             "formula": "fld_s01i208"
+        }
+    },
+    "rsutcs": {
+        "CF standard Name": "toa_outgoing_shortwave_flux_assuming_clear_sky",
+        "dimensions":{
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "W m-2",
+        "positive": "up",
+        "model_variables": [
+            "fld_s01i209"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s01i209"
         }
     },
     "rtmt": {
@@ -663,6 +772,40 @@
         "calculation": {
             "type": "direct",
             "formula": "fld_s03i236"
+        }
+    },
+    "tasmax": {
+        "CF standard Name": "air_temperature",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "K",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i236_max"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i236_max"
+        }
+    },
+    "tasmin": {
+        "CF standard Name": "air_temperature",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "K",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i236_min"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i236_min"
         }
     },
     "tauu": {

--- a/src/access_mopper/mappings/Mappings_CMIP6_Eday.json
+++ b/src/access_mopper/mappings/Mappings_CMIP6_Eday.json
@@ -10,11 +10,11 @@
         "units": "1",
         "positive": null,
         "model_variables": [
-            "fld_s30i295"
+            "fld_s30i205"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i295"
+            "formula": "fld_s30i205"
         }
     },
     "prrc": {
@@ -62,11 +62,11 @@
         "units": "K",
         "positive": null,
         "model_variables": [
-            "fld_s30i294"
+            "fld_s30i204"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i294"
+            "formula": "fld_s30i204"
         }
     },
     "ua": {
@@ -116,11 +116,11 @@
         "units": "Pa s-1",
         "positive": null,
         "model_variables": [
-            "fld_s30i298"
+            "fld_s30i208"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i298"
+            "formula": "fld_s30i208"
         }
     },
     "zg": {
@@ -138,7 +138,7 @@
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i297"
+            "formula": "fld_s30i207"
         }
     }
 }

--- a/src/access_mopper/mappings/Mappings_CMIP6_Emon.json
+++ b/src/access_mopper/mappings/Mappings_CMIP6_Emon.json
@@ -1,4 +1,19 @@
 {
+    "co23D": {
+        "dimensions":{
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "kg kg-1",
+        "model_variables": [
+            "fld_s00i252"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s00i252"
+        }
+    },
     "cSoil": {
     "dimensions":{
         "time": "time",
@@ -32,6 +47,36 @@
         "landfrac": "fld_s03i395"
       }
     }
+    },
+    "intuaw": {
+        "dimensions":{
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "kg m-1 s-1",
+        "model_variables": [
+            "fld_s30i428"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s30i428"
+        }
+    },
+    "intvaw": {
+        "dimensions":{
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "kg m-1 s-1",
+        "model_variables": [
+            "fld_s30i429"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s30i429"
+        }
     },
     "rls": {
         "dimensions":{

--- a/src/access_mopper/mappings/Mappings_CMIP6_day.json
+++ b/src/access_mopper/mappings/Mappings_CMIP6_day.json
@@ -50,6 +50,57 @@
             "formula": "fld_s03i217"
         }
     },
+    "hurs": {
+        "CF standard Name": "relative_humidity",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "%",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i245"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i245"
+        }
+    },
+    "hursmax": {
+        "CF standard Name": "relative_humidity",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "%",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i245_max"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i245_max"
+        }
+    },
+    "hursmin": {
+        "CF standard Name": "relative_humidity",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "%",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i245_min"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i245_min"
+        }
+    },
     "hus": {
         "CF standard Name": "specific_humidity",
         "dimensions": {
@@ -61,11 +112,45 @@
         "units": "1",
         "positive": null,
         "model_variables": [
-            "fld_s30i295"
+            "fld_s30i205"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i295"
+            "formula": "fld_s30i205"
+        }
+    },
+    "huss": {
+        "CF standard Name": "specific_humidity",
+        "dimensions": {
+            "time": "time",
+            "lat_v": "lat",
+            "lon_u": "lon"
+        },
+        "units": "1",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i237"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i237"
+        }
+    },
+    "pr": {
+        "CF standard Name": "precipitation_flux",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "kg m-2 s-1",
+        "positive": null,
+        "model_variables": [
+            "fld_s05i216"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s05i216"
         }
     },
     "prc": {
@@ -88,23 +173,6 @@
                 "fld_s05i205",
                 "fld_s05i206"
             ]
-        }
-    },
-    "pr": {
-        "CF standard Name": "precipitation_flux",
-        "dimensions": {
-            "time": "time",
-            "lat": "lat",
-            "lon": "lon"
-        },
-        "units": "kg m-2 s-1",
-        "positive": null,
-        "model_variables": [
-            "fld_s05i216"
-        ],
-        "calculation": {
-            "type": "direct",
-            "formula": "fld_s05i216"
         }
     },
     "prsn": {
@@ -177,7 +245,7 @@
     },
     "rlus": {
         "CF standard Name": "surface_upwelling_longwave_flux_in_air",
-        "dimensions": {
+        "dimensions":{
             "time": "time",
             "lat": "lat",
             "lon": "lon"
@@ -191,15 +259,21 @@
             "fld_s02i205"
         ],
         "calculation": {
-            "type": "formula",
-            "operation": "complex",
-            "formula": "var[0] - var[1] + var[2] - var[3]",
-            "operands": [
-                "fld_s02i207",
-                "fld_s02i201",
-                "fld_s03i332",
-                "fld_s02i205"
-            ]
+          "type": "formula",
+          "operation": "subtract",
+          "operands": [
+            {
+              "operation": "add",
+              "operands": [
+                {
+                  "operation": "subtract",
+                  "operands": ["fld_s02i207", "fld_s02i201"]
+                },
+                "fld_s03i332"
+              ]
+            },
+            "fld_s02i205"
+          ]
         }
     },
     "rlut": {
@@ -324,7 +398,58 @@
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i294"
+            "formula": "fld_s30i204"
+        }
+    },
+    "tas": {
+        "CF standard Name": "air_temperature",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "K",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i236"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i236"
+        }
+    },
+    "tasmax": {
+        "CF standard Name": "air_temperature",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "K",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i236_max"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i236_max"
+        }
+    },
+    "tasmin": {
+        "CF standard Name": "air_temperature",
+        "dimensions": {
+            "time": "time",
+            "lat": "lat",
+            "lon": "lon"
+        },
+        "units": "K",
+        "positive": null,
+        "model_variables": [
+            "fld_s03i236_min"
+        ],
+        "calculation": {
+            "type": "direct",
+            "formula": "fld_s03i236_min"
         }
     },
     "ua": {
@@ -373,7 +498,7 @@
         "units": "m s-1",
         "positive": null,
         "model_variables": [
-            "fld_s30i201"
+            "fld_s30i202"
         ],
         "calculation": {
             "type": "direct",
@@ -408,11 +533,11 @@
         "units": "Pa s-1",
         "positive": null,
         "model_variables": [
-            "fld_s30i298"
+            "fld_s30i208"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i298"
+            "formula": "fld_s30i208"
         }
     },
     "zg": {
@@ -430,7 +555,7 @@
         ],
         "calculation": {
             "type": "direct",
-            "formula": "fld_s30i297"
+            "formula": "fld_s30i207"
         }
     }
 }

--- a/src/access_mopper/mappings/Mappings_CMIP6_fx.json
+++ b/src/access_mopper/mappings/Mappings_CMIP6_fx.json
@@ -7,11 +7,11 @@
         "units": "m2",
         "positive": null,
         "model_variables": [
-            "areacella"
+            "fld_s02i204"
         ],
         "calculation": {
             "type": "direct",
-            "formula": "areacella"
+            "formula": "fld_s02i204"
         }
     },
     "sftlf": {


### PR DESCRIPTION
This pull request updates the variable mappings for CMIP6 datasets in several JSON files to improve consistency, add new variables, and correct existing mappings. The most significant changes include the addition of new variables, corrections to formulas and model variable references, and reorganization of several humidity and radiation flux variables.

**New variable additions and mapping corrections:**

* Added new variables such as `huss`, `mc`, `pfull`, `phalf`, `tasmax`, and `tasmin` to `Mappings_CMIP6_Amon.json`, with appropriate dimensions, units, and calculation formulas. [[1]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58R207-R223) [[2]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L224-R312) [[3]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58R777-R810)
* Introduced new variables `co23D`, `intuaw`, and `intvaw` to `Mappings_CMIP6_Emon.json`. [[1]](diffhunk://#diff-d6b86c480957ebef1c49b7c8b597959bef84fcc5d1a365776aee84a02e442f3aR2-R16) [[2]](diffhunk://#diff-d6b86c480957ebef1c49b7c8b597959bef84fcc5d1a365776aee84a02e442f3aR51-R80)
* Added daily relative humidity variables (`hurs`, `hursmax`, `hursmin`) to `Mappings_CMIP6_day.json`.

**Corrections and reorganization of humidity and precipitation variables:**

* Updated the mapping for specific humidity (`hus`, `huss`) and relative humidity (`hurs`) across daily, monthly, and eday mappings for consistency, including changes to model variable references and formulas. [[1]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58R207-R223) [[2]](diffhunk://#diff-e10c7b51af14f1c42b66f4e4cd0e74dbae0c7fe71818f8a1096a431ee834e901L64-R136) [[3]](diffhunk://#diff-c41b03b811b738d4c899c80a02443e2fbe795f0df807a2ee93b63974e8a8d7bcL13-R17)
* Reorganized the precipitation flux variable (`prc`) in `Mappings_CMIP6_Amon.json` and `Mappings_CMIP6_day.json`, ensuring correct calculation formulas and model variables. [[1]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L224-R312) [[2]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58R333-R354) [[3]](diffhunk://#diff-e10c7b51af14f1c42b66f4e4cd0e74dbae0c7fe71818f8a1096a431ee834e901R156-R177)

**Radiation flux variable corrections and swaps:**

* Corrected the mapping and swapped model variable references for downwelling and upwelling longwave and shortwave fluxes (`rlds`, `rldscs`, `rluscs`, `rlutcs`, `rsds`, `rsdscs`, `rsdt`, `rsuscs`, `rsutcs`) in `Mappings_CMIP6_Amon.json`, including changes to the directionality and formulas. [[1]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L345-R438) [[2]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L355-R455) [[3]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L372-R468) [[4]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L412-R512) [[5]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L446-R552) [[6]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L480-R573) [[7]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L490-R603) [[8]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L536-R629) [[9]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58L546-R642) [[10]](diffhunk://#diff-08bdd175696413eec8921fef4872645c3e949169cc86517ee95cf58172ce5c58R662-R678)

**General improvements to calculation formulas and references:**

* Updated calculation formulas for several variables to use more precise operations (e.g., changing complex formulas to nested arithmetic operations for clarity and accuracy).
* Corrected model variable references and formulas for temperature and pressure variables in `Mappings_CMIP6_Eday.json`. [[1]](diffhunk://#diff-c41b03b811b738d4c899c80a02443e2fbe795f0df807a2ee93b63974e8a8d7bcL65-R69) [[2]](diffhunk://#diff-c41b03b811b738d4c899c80a02443e2fbe795f0df807a2ee93b63974e8a8d7bcL119-R123) [[3]](diffhunk://#diff-c41b03b811b738d4c899c80a02443e2fbe795f0df807a2ee93b63974e8a8d7bcL141-R141)

These changes enhance the accuracy, completeness, and consistency of the CMIP6 variable mappings, which should help downstream data processing and analysis.